### PR TITLE
fix: 修复get_latest_bsp和bi内部bsp不统一的问题

### DIFF
--- a/BuySellPoint/BSPointList.py
+++ b/BuySellPoint/BSPointList.py
@@ -48,6 +48,8 @@ class CBSPointList(Generic[LINE_TYPE, LINE_LIST_TYPE]):
                     if bsp_list[is_buy][-1].bi.get_end_klu().idx <= self.last_sure_pos:
                         break
                     del self.bsp_store_flat_dict[bsp_list[is_buy][-1].bi.idx]
+                    # 同时把失效买卖点从Bi删除
+                    bsp_list[is_buy][-1].bi.bsp = None
                     bsp_list[is_buy].pop()
 
     def clear_bsp1_end(self):


### PR DESCRIPTION
修复get_latest_bsp和bi内部bsp不统一的问题。原因是bsp在被重置的时候，bi内部的bsp没有被同时重置，导致了bi里面有失效的bsp。详细参见这个comment： 
https://github.com/Vespa314/chan.py/commit/e40c3c745bf199c5ac6222f22e59f5082823c8f3#commitcomment-158938663